### PR TITLE
feat(mensagem): garantir dados válidos no normalizeMessage

### DIFF
--- a/src/whatsapp/message-type.js
+++ b/src/whatsapp/message-type.js
@@ -1,5 +1,9 @@
 function getMessageType (message){
     const msg = message.message;
+    if (!msg){
+        return null;
+    }
+
     if (msg.conversation){
         return "text";
     }
@@ -15,9 +19,7 @@ function getMessageType (message){
     if (msg.stikerMessage){
         return "stiker";
     }
-    if (!msg){
-        return "unknown";
-    }
+
 } 
 module.exports = {
     getMessageType

--- a/src/whatsapp/normalize-message.js
+++ b/src/whatsapp/normalize-message.js
@@ -2,12 +2,15 @@ const { GetMessageText } = require('./message-text');
 const { getMessageType } = require('./message-type');
 
 function normalizeMessage(message){
-    const text = GetMessageText(message)
-    const type = getMessageType(message)
-    const from = message.key.remoteJid
-    return {
-        text, type, from 
-    }
+    const normalize = { text : GetMessageText(message)
+     , type : getMessageType(message)
+    , from : message.key?.remoteJid }
+
+    if (!normalize.type || !normalize.from ){
+        return null; 
+    } 
+
+    return normalize
 }
 module.exports = {
     normalizeMessage

--- a/teste.js
+++ b/teste.js
@@ -1,7 +1,11 @@
-const {getMessageType} = require ('./src/whatsapp/messagetype')
-console.log(getMessageType({ message: { conversation: 'oi' } })) // 'text'
-console.log(getMessageType({ message: { imageMessage: {} } })) // 'image'
-console.log(getMessageType({ message: { audioMessage: {} } })) // 'audio'
-console.log(getMessageType({ message: {} })) // 'unknown'
+const {normalizeMessage} = require ('./src/whatsapp/normalize-message')
 
+const namorada = normalizeMessage({
+    message:{conversation: 'oi danado' }, 
+    key: { remoteJid: '5519999999999' }
+})
+const erro = normalizeMessage({ 
 
+})
+console.log(namorada) // cod certo 
+console.log(erro) // cod errado 


### PR DESCRIPTION
# Adicionei uma validação para o normalizeMenssage onde ele identifica se algo é null retornando null. 

## Para testar 
```
const {normalizeMessage} = require ('./src/whatsapp/normalize-message')

const namorada = normalizeMessage({
    message:{conversation: 'oi danado' }, 
    key: { remoteJid: '5519999999999' }
})
const erro = normalizeMessage({ 

})
console.log(namorada) // cod certo 
console.log(erro) // cod errado 

```

# Tecnologias Usadas 

<p align="left">
  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="35"/>
  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" width="35"/>
</p>

  ![tenor](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGl5b3d0eDZuN28ybHd6c2RndjhqZ29udDYxYmY0YmM2OWlyaGY1byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BDQmMy3ZM8sgRNFkhe/giphy.gif) 
